### PR TITLE
Add FastAPI service for page text extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # text_extractor_service
-Сервис для извлечения текста со страницы
+
+Сервис для извлечения текста со страницы.
+Сначала пытается скачать её через `httpx`, а при ошибке
+переходит на `undetected_chromedriver` с подменой заголовков
+и `User-Agent` при помощи `fake-headers` и `fake-useragent`.
+
+## Запуск
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+## Пример запроса
+
+```bash
+curl -X POST http://localhost:8000/extract \
+     -H 'Content-Type: application/json' \
+     -d '{"url": "https://example.com"}'
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,49 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, HttpUrl
+import httpx
+from bs4 import BeautifulSoup
+import asyncio
+import undetected_chromedriver as uc
+from fake_headers import Headers
+from fake_useragent import UserAgent
+
+app = FastAPI()
+
+class URLRequest(BaseModel):
+    url: HttpUrl
+
+def _fetch_with_browser(url: str) -> str:
+    ua = UserAgent().random
+    headers = Headers().generate()
+    headers["User-Agent"] = ua
+
+    options = uc.ChromeOptions()
+    options.add_argument("--headless=new")
+    options.add_argument(f"--user-agent={ua}")
+
+    driver = uc.Chrome(options=options)
+    try:
+        driver.execute_cdp_cmd("Network.enable", {})
+        driver.execute_cdp_cmd("Network.setExtraHTTPHeaders", {"headers": headers})
+        driver.get(url)
+        return driver.page_source
+    finally:
+        driver.quit()
+
+
+@app.post("/extract")
+async def extract_text(req: URLRequest):
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(str(req.url))
+            response.raise_for_status()
+            html = response.text
+    except httpx.HTTPError:
+        try:
+            html = await asyncio.to_thread(_fetch_with_browser, str(req.url))
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+
+    soup = BeautifulSoup(html, "html.parser")
+    text = soup.get_text(separator="\n", strip=True)
+    return {"text": text}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn[standard]
+httpx
+beautifulsoup4
+undetected-chromedriver
+fake-headers
+fake-useragent


### PR DESCRIPTION
## Summary
- add FastAPI app with endpoint to fetch a URL and return parsed text
- document setup and usage instructions
- declare required packages
- fallback to undetected_chromedriver with fake headers and user agent when httpx fails

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b42b1d70f88330afa458a70fecd42c